### PR TITLE
Custom mdx and styling MindMii

### DIFF
--- a/src/app/components/Footer.tsx
+++ b/src/app/components/Footer.tsx
@@ -4,7 +4,7 @@ import { MdEmail } from 'react-icons/md';
 export default function Footer() {
   return (
     <footer className="row-start-3 flex gap-6 flex-wrap items-center justify-center p-4">
-      <nav className='row-start-3 flex gap-6 flex-wrap' aria-label="Footer Navigation">
+      <nav className='tiny:row-start-3 tiny:flex gap-6 tiny:flex-wrap' aria-label="Footer Navigation">
         <a
           className="flex items-center gap-2 hover:underline hover:underline-offset-4"
           href="https://linkedin.com/in/kingdrewsea"

--- a/src/app/components/Footer.tsx
+++ b/src/app/components/Footer.tsx
@@ -4,53 +4,55 @@ import { MdEmail } from 'react-icons/md';
 export default function Footer() {
   return (
     <footer className="row-start-3 flex gap-6 flex-wrap items-center justify-center p-4">
-      <a
-        className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-        href="https://linkedin.com/in/kingdrewsea"
-        target="_blank"
-        rel="noopener noreferrer"
-        aria-label="Visit LinkedIn Profile"
-      >
-        <Image
-          src="/images/LinkedIn.png"
-          alt="LinkedIn logo in blue"
-          width={16}
-          height={16}
-          aria-hidden="true"
-        />
-        LinkedIn
-      </a>
-      
-      <a
-        className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-        href="https://github.com/andrewpking"
-        target="_blank"
-        rel="noopener noreferrer"
-        aria-label="Visit GitHub Profile"
-      >
-        <Image
-          src="/images/github.svg"
-          alt="Github logo"
-          width={16}
-          height={16}
-          aria-hidden="true"
-          className="dark:invert transition-[filter] duration-300"
-        />
-        GitHub
-      </a>
-      
-      <a
-        className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-        href="mailto:drewpking@pm.me"
-        aria-label="Send email"
-      >
-        <MdEmail
+      <nav aria-label="Footer Navigation">
+        <a
+          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
+          href="https://linkedin.com/in/kingdrewsea"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Visit LinkedIn Profile"
+        >
+          <Image
+            src="/images/LinkedIn.png"
+            alt="LinkedIn logo in blue"
+            width={16}
+            height={16}
             aria-hidden="true"
-            size={16}
-         />
+          />
+          LinkedIn
+        </a>
         
-        Email
-      </a>
+        <a
+          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
+          href="https://github.com/andrewpking"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Visit GitHub Profile"
+        >
+          <Image
+            src="/images/github.svg"
+            alt="Github logo"
+            width={16}
+            height={16}
+            aria-hidden="true"
+            className="dark:invert transition-[filter] duration-300"
+          />
+          GitHub
+        </a>
+        
+        <a
+          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
+          href="mailto:drewpking@pm.me"
+          aria-label="Send email"
+        >
+          <MdEmail
+              aria-hidden="true"
+              size={16}
+          />
+          
+          Email
+        </a>
+      </nav>
     </footer>
   );
 }

--- a/src/app/components/Footer.tsx
+++ b/src/app/components/Footer.tsx
@@ -4,7 +4,7 @@ import { MdEmail } from 'react-icons/md';
 export default function Footer() {
   return (
     <footer className="row-start-3 flex gap-6 flex-wrap items-center justify-center p-4">
-      <nav aria-label="Footer Navigation">
+      <nav className='row-start-3 flex gap-6 flex-wrap' aria-label="Footer Navigation">
         <a
           className="flex items-center gap-2 hover:underline hover:underline-offset-4"
           href="https://linkedin.com/in/kingdrewsea"

--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -32,7 +32,7 @@ export default function Header() {
         <header className="w-full shadow-sm fixed top-0 z-50">
             <div className="max-w-7xl mx-auto px-4 md:px-6 lg:px-8">
             <p className='ml-2 text-center hidden md:block'>Drew King&apos;s Portfolio</p>
-                <nav className="flex items-center justify-between h-16">
+                <nav aria-label="Main navigation" className="flex items-center justify-between h-16">
                     {/* Mobile menu button */}
                     <button 
                         className="md:hidden"

--- a/src/app/components/MdxPage.tsx
+++ b/src/app/components/MdxPage.tsx
@@ -1,48 +1,13 @@
-import Image from 'next/image';
-import Header from './Header';
-import PageMetadata from './Metadata';
-import Footer from './Footer';
 import '../styles.scss';
 
 interface MdxPageProps {
-    meta: PageMetadata;
     children?: React.ReactNode;
 }
 
-const MdxPage: React.FC<MdxPageProps> = ({ meta, children }) => {
+export default function MdxPage ({ children }: MdxPageProps) {
     return (
-        <>
-            <Header />
-            <main className="project-page">
-                <div className="image-head-container relative md:mt-20 md:pt-4 sm:mt-12 sm:pt-0">
-                    <Image 
-                        src={meta.image} 
-                        alt={meta.imageAlt} 
-                        width={1120} 
-                        height={150}
-                        className="w-full h-[250px] md:h-[200px] object-cover"
-                        priority
-                    />
-                    <div className="absolute inset-0 overlay"></div>
-                    <div className="absolute inset-0 flex flex-col items-center justify-center p-4">
-                        <h1 className="text-4xl font-bold">
-                            {meta.title}
-                        </h1>
-                        <p className="hidden sm:block text-center">
-                            {meta.description}
-                        </p>
-                    </div>
-                </div>
-
-                {/* Visible only on screens smaller than md */}
-                <p className="sm:hidden text-center px-4 py-6">
-                    {meta.description}
-                </p>
-                {children}
-            </main>
-            <Footer />
-        </>
+        <main className="project-page">
+            {children}
+        </main>
     );
 }
-
-export default MdxPage;

--- a/src/app/components/PageHeading.tsx
+++ b/src/app/components/PageHeading.tsx
@@ -10,10 +10,12 @@ export default function PageHeading ({metadata}: PageHeadingProps) {
         <>
             <div className="image-head-container relative md:mt-20 md:pt-4 sm:mt-12 sm:pt-0">
                 <Image 
+                    fill={false}
                     src={metadata.image} 
                     alt={metadata.imageAlt} 
                     width={1120} 
                     height={150}
+                    sizes= "width: 100vw, height: 10vh"
                     className="w-full h-[250px] md:h-[200px] object-cover"
                     priority
                 />

--- a/src/app/components/PageHeading.tsx
+++ b/src/app/components/PageHeading.tsx
@@ -1,0 +1,37 @@
+import type PageMetadata from './Metadata';
+import Image from 'next/image';
+
+interface PageHeadingProps {
+    metadata: PageMetadata;
+}
+
+export default function PageHeading ({metadata}: PageHeadingProps) {
+    return (
+        <>
+            <div className="image-head-container relative md:mt-20 md:pt-4 sm:mt-12 sm:pt-0">
+                <Image 
+                    src={metadata.image} 
+                    alt={metadata.imageAlt} 
+                    width={1120} 
+                    height={150}
+                    className="w-full h-[250px] md:h-[200px] object-cover"
+                    priority
+                />
+                <div className="absolute inset-0 overlay"></div>
+                <div className="absolute inset-0 flex flex-col items-center justify-center p-4">
+                    <h1 className="text-4xl font-bold">
+                        {metadata.title}
+                    </h1>
+                    <p className="hidden sm:block text-center">
+                        {metadata.description}
+                    </p>
+                </div>
+            </div>
+        
+            {/* Visible only on screens smaller than md */}
+            <p className="sm:hidden text-center px-4 py-6">
+                {metadata.description}
+            </p>
+        </>
+    )
+}

--- a/src/app/components/ProjectImagesBlock.tsx
+++ b/src/app/components/ProjectImagesBlock.tsx
@@ -18,8 +18,8 @@ interface ProjectImagesBlockProps {
 
 const ProjectImagesBlock: React.FC<ProjectImagesBlockProps> = ({ images, direction = 'row', width, maxHeight, caption, children }) => {
   return (
-    <div className="w-full max-w-7xl mx-auto tiny:block sm:flex flex-row ">
-      <section className="tiny:block sm:flex-1">
+    <div className={`max-w-7xl mx-auto tiny:block sm:flex flex-row`}>
+      <section className={`tiny:block sm:flex-1 ${direction === 'column' ? `w-[${width * 100}px]` : `w-[${width * 100 * images.length}]px`}`}>
         <div className={`grid gap-6 ${
           direction === 'row' 
             ? `grid-cols-1 ${
@@ -36,23 +36,24 @@ const ProjectImagesBlock: React.FC<ProjectImagesBlockProps> = ({ images, directi
                  className={`flex flex-col ${
                    direction === 'column' ? 'mb-6' : ''
                  }`}>
-              <div className="w-full sm:max-w-[700px] md:max-w-[900px] mx-auto">
+              <div className="sm:max-w-[700px] md:max-w-[900px] mx-auto">
                 <Image 
+                  fill={false}
                   src={image.src} 
                   alt={image.alt}
                   width={width * 100}
                   height={maxHeight}
-                  className="rounded-lg w-full"
+                  className="rounded-lg"
                 />
               </div>
               {image.caption && (
-                <p className="text-sm italic">{image.caption}</p>
+                <p className="italic">{image.caption}</p>
               )}
             </div>
           ))}
         </div>
         {caption && (
-          <p className="mt-4 text-sm italic">{caption}</p>
+          <p className="mt-4 italic">{caption}</p>
         )}
       </section>
       {children && (

--- a/src/app/components/ProjectTeamGallery.tsx
+++ b/src/app/components/ProjectTeamGallery.tsx
@@ -13,10 +13,11 @@ interface ProjectTeamGalleryProps {
 
 const ProjectTeamGallery: React.FC<ProjectTeamGalleryProps> = ({ members }) => {
   return (
-    <section className="team-gallery, grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
+    <section aria-label='Team Photos' className="team-gallery, grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
       {members.map((member, index) => (
         <div key={index} className="team-member flex flex-col items-center gap-4">
           <Image
+            fill={false}
             src={member.photo || defaultPhoto}
             alt={`Photo of ${member.name[0]}.`}
             className="team-member-photo"

--- a/src/app/high-speed-rail/page.mdx
+++ b/src/app/high-speed-rail/page.mdx
@@ -1,9 +1,8 @@
-import MdxPage from '../components/MdxPage'
 import TrainBuilderDashboard from './components/Dashboard'
-import {projects} from '../components/pages'
-import '../styles.scss'
+import { projects } from '../components/pages';
+import PageHeading from '../components/PageHeading';
 
-<MdxPage meta={projects['/high-speed-rail']}>
+<PageHeading metadata={projects['/high-speed-rail']} />
 
 The High Speed Rail project is a conceptual train builder for a high-speed rail system in the United States. The goal of the project is to provide a fast, efficient, and sustainable mode of transportation that connects major cities across the country. The project envisions a network of high-speed trains that travel at speeds of up to 300 miles per hour, making it possible to travel between cities in a matter of hours. We estimated the ridership by analyzing the population density and distance between major cities in the United States.
 
@@ -38,5 +37,3 @@ The project was built using React, a JavaScript library for building user interf
 ### Deployment
 
 The [original High Speed Rail project](https://high-speed-rail-cse442-24au-fp-6a981c250f8bd8e994fe6608199c4157.pages.cs.washington.edu/) was deployed to gitlab pages with additional visualizations created by Joey Kreuger and styles by Jack Rosenbloom. We used a custom build script to generate the static files and deploy them to a web server using GitLab CI/CD.
-
-</MdxPage>

--- a/src/app/kbcs/page.mdx
+++ b/src/app/kbcs/page.mdx
@@ -1,8 +1,8 @@
-import MdxPage from '../components/MdxPage'
-import {projects} from '../components/pages'
-import '../styles.scss'
+import { projects } from '../components/pages';
+import PageHeading from '../components/PageHeading';
 
-<MdxPage meta={projects['/kbcs']}>
+<PageHeading metadata={projects['/kbcs']} />
+
 By [Sama Khalid][1], [Drew King][2], [Colin Xiao][3], and [Sophia Lin][4]
 
 ## Introduction
@@ -131,5 +131,3 @@ Ultimately, we aspire to make a tangible impact in the real world by contributin
 [16]: https://drive.google.com/file/d/17SiwtH7Ux7M1nmmgETcM9AZ3GzsUQnIy/view?usp=drive_link
 
 [image-1]: /images/KBCS_Menu-Bar_Flow.png "Figure 1"
-
-</MdxPage>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import Header from "./components/Header";
+import Footer from "./components/Footer";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -27,7 +29,9 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
+        <Header />
         {children}
+        <Footer />
       </body>
     </html>
   );

--- a/src/app/mindmii/page.mdx
+++ b/src/app/mindmii/page.mdx
@@ -166,15 +166,13 @@ We explored solutions based on our research to develop MindMii, a mobile app and
 - **Easily identify and respond to missed messages**
 - **Respond to a message in an appropriate amount of time**
 
-</ProjectImagesBlock>
-
 The iterative design process we used includes usability testing, heuristic evaluation, and more usability testing. We found the paper prototype very effective in testing to identify many of the most severe issues in our design, resulting in a broad yet rapid testing and inspection process.
 
 In our first paper prototype people found it hard to understand how to interact with MindMii because it did not follow conventions of instant messaging platforms participants were familiar with. An issue that came up in our second paper prototype is clarity around the availability of features earlier in the messaging flow. A digital mockup was created from the earlier iterations, providing context for improvement by iterative revision.
+</ProjectImagesBlock>
+
 
 Our iterative design process revealed key insights which supported continued design improvement. Three of these key insights were:
-
-### The watch notifications needed more clarity of design and interactivity.
 
 <ProjectImagesBlock
     images={[
@@ -194,6 +192,7 @@ Our iterative design process revealed key insights which supported continued des
     width={2}
     maxHeight={400}
 >
+### The watch notifications needed more clarity of design and interactivity.
 
 An issue identified from user testing was confusion about how to interact with the watch notification which appears as a color ring. This confusion was identified by participant feedback during paper prototype testing, when they wanted to know what to do about the color ring and weren't sure if or how to suppress or interact with the notification. To support this issue, we added a bell icon to the color ring which provides a signifier to the to the user indicating that this is a notification, following conventions in this design space.
 
@@ -221,8 +220,6 @@ During each of our 3 user tests we received questions regarding the style used t
 
 </ProjectImagesBlock>
 
-### Suggestive features should provide more types of help.
-
 <ProjectImagesBlock
     images={[
         {
@@ -241,12 +238,11 @@ During each of our 3 user tests we received questions regarding the style used t
     width={3}
     maxHeight={400}
 >
+### Suggestive features should provide more types of help.
 
 Our original suggestive response feature only provided texting suggestions and did not provide other types of help, an issue uncovered during a paper prototype interaction with participants. They found this issue when they performed the task of "identifying and responding to a missed message". The participant wanted send a different message than the options provided by MindMii's suggestive text. We expanded our suggestive text helper to one that provides general help features by accepting a prompt and allowing for regeneration of suggestions.
 
 </ProjectImagesBlock>
-
-### More action options should be provided in more places.
 
 <ProjectImagesBlock
     images={[
@@ -258,9 +254,10 @@ Our original suggestive response feature only provided texting suggestions and d
     caption={
         "By offering response assistance outside of opening a message we reduce some response anxiety that is cause by fear of 'leaving someone on read.'"
     }
-    width={4}
-    maxHeight={400}
+    width={3}
+    maxHeight={300}
 >
+### More action options should be provided in more places.
 
 The initial MindMii prototype's message response interface focused heavily on replying without offering other options such as accessing help or suggestions. This was an issue uncovered through paper prototype testing by participants. The ability to access features like help was buried too deeply in our design and needed to be hoisted into the earlier phases of the interaction. We noticed based on feedback that more types of help should be provided in addition to increased access to help and AI suggestions. We added assistive buttons to the text screen to provide help as an alternative to drafting a response.
 

--- a/src/app/mindmii/page.mdx
+++ b/src/app/mindmii/page.mdx
@@ -235,7 +235,7 @@ During each of our 3 user tests we received questions regarding the style used t
     caption={
         "The right-hand image showing our final design offers help based on what is asked in open-format, rather than default offering a suggested selection of potential replies."
     }
-    width={3}
+    width={2}
     maxHeight={400}
 >
 ### Suggestive features should provide more types of help.

--- a/src/app/mindmii/page.mdx
+++ b/src/app/mindmii/page.mdx
@@ -2,9 +2,10 @@ import ProjectImagesBlock from "../components/ProjectImagesBlock";
 import ProjectTeamGallery from "../components/ProjectTeamGallery";
 import Head from 'next/head';
 import Image from 'next/image';
-import MdxPage from '../components/MdxPage';
-import {projects} from '../components/pages'
-import '../styles.scss';
+import { projects } from '../components/pages';
+import PageHeading from '../components/PageHeading';
+
+<PageHeading metadata={projects['/mindmii']} />
 
 export const images = {
   imageTeamPerson1: "/images/mindmii/Drew.png",
@@ -38,7 +39,6 @@ export const images = {
   watchFour: "/images/mindmii/watch_4.png",
 };
 
-<MdxPage meta = {projects['/mindmii']}>
 ## Team
 
   <ProjectTeamGallery
@@ -371,5 +371,3 @@ Using the keyboard, the person drafts a response to the message. Upon completion
 Examining our other task to respond to a message in an appropriate amount of time, our scenario has MindMii notifying the person of an urgent message from earlier that needs a reply soon. The person decides to snooze the message since they are busy, but the app AI recognizes this message is time-sensitive and limits the snooze to five minutes. Following this, it re-prompts the person about this message and they realize the urgency of the message.
 
 The person opens the message and enters into reply mode. AI is there to support with suggestions, but the user composes a message of their own using the keyboard and presses send. The response is routed to the platform the message is native to. The notification is cleared from the lock screen. Messages are no longer forgotten with MindMii!
-
-</MdxPage>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,14 +1,11 @@
 import PreviewCard from "./components/PreviewCard";
 import { projects } from "./components/pages";
-import Header from "./components/Header";
-import Footer from "./components/Footer";
 import PageMetadata from "./components/Metadata";
 import "./styles.scss";
 
 export default function Home() {
   return (
     <div>
-      <Header />
       <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20 font-[family-name:var(--font-geist-sans)]">
         <main className="row-start-2 flex flex-col items-center justify-center gap-6">
           <h1 className="text-center">
@@ -27,7 +24,6 @@ export default function Home() {
             ))}
           </div>
         </main>
-        <Footer />
       </div>
     </div>
   );

--- a/src/app/resitogether/page.mdx
+++ b/src/app/resitogether/page.mdx
@@ -1,10 +1,9 @@
-import MdxPage from '../components/MdxPage'
 import FigmaEmbed from '../components/FigmaEmbed'
 import ProjectImagesBlock from '../components/ProjectImagesBlock'
-import {projects} from '../components/pages'
-import '../styles.scss'
+import { projects } from '../components/pages';
+import PageHeading from '../components/PageHeading';
 
-<MdxPage meta={projects['/resitogether']}>
+<PageHeading metadata={projects['/resitogether']} />
 
 ResiTogether is an app designed to increase employment among formerly incarcerated persons. The app is designed to help formerly incarcerated individuals find jobs, connect with resources, and build a community. The app is designed to be user-friendly and accessible to all users, regardless of their background or experience with technology. The app is designed to be a one-stop shop for formerly incarcerated individuals looking for employment, providing them with the tools and resources they need to succeed in the job market. The app is designed to be a safe and supportive space for formerly incarcerated individuals to connect with others who have shared experiences and build a community of support. The app is designed to be a valuable resource for formerly incarcerated individuals looking to rebuild their lives and find meaningful employment opportunities.
 
@@ -218,5 +217,3 @@ Zoukis, C. (2022, May 10). [_Vocational training in prison_](https://federalcrim
 
 ### Appendix
 [Survey Results](https://docs.google.com/spreadsheets/d/1pPg270%5C_Z8%5C_xD48dn18CyFRJzVdZE51yo2kzd2-uGyB8/edit?usp=sharing%20)
-
-</MdxPage>

--- a/src/app/sl-screens/page.mdx
+++ b/src/app/sl-screens/page.mdx
@@ -1,8 +1,7 @@
-import MdxPage from '../components/MdxPage'
-import {projects} from '../components/pages'
-import '../styles.scss'
+import { projects } from '../components/pages';
+import PageHeading from '../components/PageHeading';
 
-<MdxPage meta={projects['/sl-screens']}>
+<PageHeading metadata={projects['/sl-screens']} />
 
 Drew King<sup>1</sup>; Brian Williamson, PhD<sup>2</sup>; and Ying Huang, PhD<sup>2</sup>
 
@@ -52,5 +51,3 @@ Conduct further research including:
 * Building this experiment in other programming language such as C or Python for better performance
 
 Following publication, results will be replicable by others with scientific computing tools.
-
-</MdxPage>

--- a/src/mdx-components.tsx
+++ b/src/mdx-components.tsx
@@ -1,7 +1,11 @@
-import type { MDXComponents } from 'mdx/types'
+import type { MDXComponents } from 'mdx/types';
+import MdxPage from './app/components/MdxPage';
  
 export function useMDXComponents(components: MDXComponents): MDXComponents {
   return {
     ...components,
-  }
+    wrapper: ({ children }) => {
+      return <MdxPage>{children}</MdxPage>;
+    }
+  };
 }


### PR DESCRIPTION
### Better use of nextJS conventions for rendering MDX

- Header and footer are now rendered once in `layout.tsx`
- Headings in mdx pages now have their own component which is placed at the top of each mdx page.
- `MdxPage` now serves as a wrapper for mdx pages which ensures styles are imported and content is in a main

### Restyled MindMii

- MindMii now has fewer visual bugs, thanks to better understanding of defining box sizes in tailwind by using variables.
- Made some of the image groups smaller so it is not oversize on the screen