### PR TITLE
Mdx pages now render as static components.

### DIFF
--- a/src/app/components/MdxPage.tsx
+++ b/src/app/components/MdxPage.tsx
@@ -1,10 +1,24 @@
+import { Metadata } from 'next';
 import '../styles.scss';
 
 interface MdxPageProps {
     children?: React.ReactNode;
 }
 
-export default function MdxPage ({ children }: MdxPageProps) {
+// Force static rendering
+export const dynamic = 'force-static';
+export const revalidate = false;
+
+// Static metadata
+export const generateMetadata = (): Metadata => {
+    return {
+        other: {
+            'Cache-Control': 'public, max-age=31536000, immutable'
+        }
+    };
+};
+
+export default function MdxPage({ children }: MdxPageProps) {
     return (
         <main id="main-content" tabIndex={-1} className="project-page">
             {children}

--- a/src/mdx-components.tsx
+++ b/src/mdx-components.tsx
@@ -1,5 +1,9 @@
 import type { MDXComponents } from 'mdx/types';
 import MdxPage from './app/components/MdxPage';
+
+// Force static rendering
+export const dynamic = 'force-static';
+export const revalidate = false;
  
 export function useMDXComponents(components: MDXComponents): MDXComponents {
   return {


### PR DESCRIPTION
Used [docs from nextJS](https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config) to render pages statically for better SEO.